### PR TITLE
fix: 구독 해제가 되지 않던 에러 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'com.github.f4b6a3:ulid-creator:5.2.3'
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+//    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/curioussong/alsongdalsong/channel/domain/ChannelChat.java
+++ b/src/main/java/com/curioussong/alsongdalsong/channel/domain/ChannelChat.java
@@ -1,18 +1,18 @@
-package com.curioussong.alsongdalsong.channel.domain;
-
-import lombok.Builder;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.time.LocalDateTime;
-
-@Document(collection = "channel_chat")
-@Builder
-public class ChannelChat {
-    @Id
-    private String id;
-    private Long memberId;
-    private Long channelId;
-    private String message;
-    private LocalDateTime chattedAt;
-}
+//package com.curioussong.alsongdalsong.channel.domain;
+//
+//import lombok.Builder;
+//import org.springframework.data.annotation.Id;
+//import org.springframework.data.mongodb.core.mapping.Document;
+//
+//import java.time.LocalDateTime;
+//
+//@Document(collection = "channel_chat")
+//@Builder
+//public class ChannelChat {
+//    @Id
+//    private String id;
+//    private Long memberId;
+//    private Long channelId;
+//    private String message;
+//    private LocalDateTime chattedAt;
+//}

--- a/src/main/java/com/curioussong/alsongdalsong/channel/event/ChannelChatSaveEventListener.java
+++ b/src/main/java/com/curioussong/alsongdalsong/channel/event/ChannelChatSaveEventListener.java
@@ -1,28 +1,28 @@
-package com.curioussong.alsongdalsong.channel.event;
-
-import com.curioussong.alsongdalsong.channel.domain.ChannelChat;
-import com.curioussong.alsongdalsong.channel.repository.ChannelChatRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
-
-@Component
-@RequiredArgsConstructor
-public class ChannelChatSaveEventListener {
-
-    private final ChannelChatRepository channelChatRepository;
-
-    @Async
-    @EventListener
-    public void handleChannelChatSaveEvent(ChannelChatSaveEvent event) {
-        ChannelChat channelChat = ChannelChat.builder()
-                .memberId(event.member().getId())
-                .channelId(event.channel().getId())
-                .message(event.message())
-                .chattedAt(event.timeStamp())
-                .build();
-
-        channelChatRepository.save(channelChat);
-    }
-}
+//package com.curioussong.alsongdalsong.channel.event;
+//
+//import com.curioussong.alsongdalsong.channel.domain.ChannelChat;
+//import com.curioussong.alsongdalsong.channel.repository.ChannelChatRepository;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.context.event.EventListener;
+//import org.springframework.scheduling.annotation.Async;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class ChannelChatSaveEventListener {
+//
+//    private final ChannelChatRepository channelChatRepository;
+//
+//    @Async
+//    @EventListener
+//    public void handleChannelChatSaveEvent(ChannelChatSaveEvent event) {
+//        ChannelChat channelChat = ChannelChat.builder()
+//                .memberId(event.member().getId())
+//                .channelId(event.channel().getId())
+//                .message(event.message())
+//                .chattedAt(event.timeStamp())
+//                .build();
+//
+//        channelChatRepository.save(channelChat);
+//    }
+//}

--- a/src/main/java/com/curioussong/alsongdalsong/channel/repository/ChannelChatRepository.java
+++ b/src/main/java/com/curioussong/alsongdalsong/channel/repository/ChannelChatRepository.java
@@ -1,7 +1,7 @@
-package com.curioussong.alsongdalsong.channel.repository;
-
-import com.curioussong.alsongdalsong.channel.domain.ChannelChat;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface ChannelChatRepository extends MongoRepository<ChannelChat, String> {
-}
+//package com.curioussong.alsongdalsong.channel.repository;
+//
+//import com.curioussong.alsongdalsong.channel.domain.ChannelChat;
+//import org.springframework.data.mongodb.repository.MongoRepository;
+//
+//public interface ChannelChatRepository extends MongoRepository<ChannelChat, String> {
+//}

--- a/src/main/java/com/curioussong/alsongdalsong/channel/service/ChannelService.java
+++ b/src/main/java/com/curioussong/alsongdalsong/channel/service/ChannelService.java
@@ -98,6 +98,6 @@ public class ChannelService {
         Member member = memberRepository.findByUsername(chatRequestDTO.getRequest().getSender())
                 .orElseThrow(() -> new StompException(StompError.USER_NOT_FOUND));
 
-        eventPublisher.publishEvent(new ChannelChatSaveEvent(member, channel, chatRequestDTO.getRequest().getMessage(), LocalDateTime.now()));
+//        eventPublisher.publishEvent(new ChannelChatSaveEvent(member, channel, chatRequestDTO.getRequest().getMessage(), LocalDateTime.now()));
     }
 }

--- a/src/main/java/com/curioussong/alsongdalsong/config/StompJwtChannelInterceptor.java
+++ b/src/main/java/com/curioussong/alsongdalsong/config/StompJwtChannelInterceptor.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
@@ -24,6 +25,10 @@ public class StompJwtChannelInterceptor implements ChannelInterceptor {
 
         if (accessor != null && accessor.getCommand() != null) {
             String authHeader = accessor.getFirstNativeHeader("Authorization");
+
+            if (accessor.getCommand() == StompCommand.UNSUBSCRIBE || accessor.getCommand() == StompCommand.DISCONNECT) {
+                return message;
+            }
 
             if (authHeader != null && authHeader.startsWith("Bearer ")) {
                 String token = authHeader.substring(7);

--- a/src/main/java/com/curioussong/alsongdalsong/game/domain/GameChat.java
+++ b/src/main/java/com/curioussong/alsongdalsong/game/domain/GameChat.java
@@ -1,21 +1,21 @@
-package com.curioussong.alsongdalsong.game.domain;
-
-import com.curioussong.alsongdalsong.gameround.domain.GameRound;
-import com.curioussong.alsongdalsong.member.domain.Member;
-import lombok.Builder;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.time.LocalDateTime;
-
-@Document(collection = "game_chat")
-@Builder
-public class GameChat {
-    @Id
-    private String id;
-    private Long memberId;
-    private Long gameSessionId;
-    private Long gameRoundId;
-    private String message;
-    private LocalDateTime chattedAt;
-}
+//package com.curioussong.alsongdalsong.game.domain;
+//
+//import com.curioussong.alsongdalsong.gameround.domain.GameRound;
+//import com.curioussong.alsongdalsong.member.domain.Member;
+//import lombok.Builder;
+//import org.springframework.data.annotation.Id;
+//import org.springframework.data.mongodb.core.mapping.Document;
+//
+//import java.time.LocalDateTime;
+//
+//@Document(collection = "game_chat")
+//@Builder
+//public class GameChat {
+//    @Id
+//    private String id;
+//    private Long memberId;
+//    private Long gameSessionId;
+//    private Long gameRoundId;
+//    private String message;
+//    private LocalDateTime chattedAt;
+//}

--- a/src/main/java/com/curioussong/alsongdalsong/game/event/GameChatSaveEventListener.java
+++ b/src/main/java/com/curioussong/alsongdalsong/game/event/GameChatSaveEventListener.java
@@ -1,31 +1,31 @@
-package com.curioussong.alsongdalsong.game.event;
-
-import com.curioussong.alsongdalsong.game.domain.GameChat;
-import com.curioussong.alsongdalsong.game.repository.GameChatRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
-
-import java.time.LocalDateTime;
-
-@Component
-@RequiredArgsConstructor
-public class GameChatSaveEventListener {
-
-    private final GameChatRepository gameChatRepository;
-
-    @Async
-    @EventListener
-    public void handleGameChatSaveEvent(GameChatSaveEvent event) {
-        GameChat gameChat = GameChat.builder()
-                .memberId(event.memberId())
-                .gameSessionId(event.gameSessionId())
-                .gameRoundId(event.gameRoundId())
-                .message(event.message())
-                .chattedAt(LocalDateTime.now())
-                .build();
-
-        gameChatRepository.save(gameChat);
-    }
-}
+//package com.curioussong.alsongdalsong.game.event;
+//
+//import com.curioussong.alsongdalsong.game.domain.GameChat;
+//import com.curioussong.alsongdalsong.game.repository.GameChatRepository;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.context.event.EventListener;
+//import org.springframework.scheduling.annotation.Async;
+//import org.springframework.stereotype.Component;
+//
+//import java.time.LocalDateTime;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class GameChatSaveEventListener {
+//
+//    private final GameChatRepository gameChatRepository;
+//
+//    @Async
+//    @EventListener
+//    public void handleGameChatSaveEvent(GameChatSaveEvent event) {
+//        GameChat gameChat = GameChat.builder()
+//                .memberId(event.memberId())
+//                .gameSessionId(event.gameSessionId())
+//                .gameRoundId(event.gameRoundId())
+//                .message(event.message())
+//                .chattedAt(LocalDateTime.now())
+//                .build();
+//
+//        gameChatRepository.save(gameChat);
+//    }
+//}

--- a/src/main/java/com/curioussong/alsongdalsong/game/repository/GameChatRepository.java
+++ b/src/main/java/com/curioussong/alsongdalsong/game/repository/GameChatRepository.java
@@ -1,8 +1,8 @@
-package com.curioussong.alsongdalsong.game.repository;
-
-import com.curioussong.alsongdalsong.game.domain.GameChat;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface GameChatRepository extends MongoRepository<GameChat, String> {
-    
-}
+//package com.curioussong.alsongdalsong.game.repository;
+//
+//import com.curioussong.alsongdalsong.game.domain.GameChat;
+//import org.springframework.data.mongodb.repository.MongoRepository;
+//
+//public interface GameChatRepository extends MongoRepository<GameChat, String> {
+//
+//}

--- a/src/main/java/com/curioussong/alsongdalsong/game/service/GameService.java
+++ b/src/main/java/com/curioussong/alsongdalsong/game/service/GameService.java
@@ -61,9 +61,10 @@ public class GameService {
             return;
         }
 
-        if (room.getStatus() == Room.RoomStatus.IN_PROGRESS) {
-            saveInGameChat(chatRequestDTO, roomId);
-        }
+        // 추후 mongodb 연결 시 주석 해제
+//        if (room.getStatus() == Room.RoomStatus.IN_PROGRESS) {
+//            saveInGameChat(chatRequestDTO, roomId);
+//        }
 
         gameMessageSender.sendChat(chatRequestDTO, destination);
 


### PR DESCRIPTION
## 🤷‍♂ Description

> 작업 내용에 대한 설명

- 구독 해제 메시지는 헤더에 토큰을 담아보내주지 않기에, socket interceptor에서 이를 정상적으로 수신하지 않던 오류를 수정하였습니다.
- 구독 해제, 연결 해제 메시지의 경우 바로 리턴하도록 수정하였습니다.

## 📷 Screenshots

> 작업 결과물

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항