### PR TITLE
refactor: roomService의 책임 분리

### DIFF
--- a/src/main/java/com/curioussong/alsongdalsong/game/domain/RoomManager.java
+++ b/src/main/java/com/curioussong/alsongdalsong/game/domain/RoomManager.java
@@ -184,7 +184,7 @@ public class RoomManager {
         List<UserInfo> userInfoList = new ArrayList<>();
 
         for (Member member : room.getMembers()) {
-            boolean isHost = member.getId().equals(room.getHost().getId());
+            boolean isHost = room.isHost(member);
             boolean isReady = Boolean.TRUE.equals(getReady(room.getId(), member.getId()));
             String colorCode = member.getColorCode();
             Integer colorNumber = getUserColorNumber(room.getId(), member.getUsername());

--- a/src/main/java/com/curioussong/alsongdalsong/room/domain/Room.java
+++ b/src/main/java/com/curioussong/alsongdalsong/room/domain/Room.java
@@ -148,4 +148,8 @@ public class Room {
     public void assignRoomNumber(Long roomNumber) {
         this.roomNumber = roomNumber;
     }
+
+    public boolean isHost(Member member) {
+        return this.getHost().getId().equals(member.getId());
+    }
 }

--- a/src/main/java/com/curioussong/alsongdalsong/room/event/RoomEventNotifier.java
+++ b/src/main/java/com/curioussong/alsongdalsong/room/event/RoomEventNotifier.java
@@ -1,0 +1,26 @@
+package com.curioussong.alsongdalsong.room.event;
+
+import com.curioussong.alsongdalsong.member.domain.Member;
+import com.curioussong.alsongdalsong.member.event.MemberLocationEvent;
+import com.curioussong.alsongdalsong.room.domain.Room;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomEventNotifier {
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void notifyRommEvent(Room room, Long channelId, RoomUpdatedEvent.ActionType type) {
+        eventPublisher.publishEvent(new RoomUpdatedEvent(room, channelId, type));
+    }
+
+    public void notifyUserJoined(String roomId, String sessionId, String username) {
+        eventPublisher.publishEvent(new UserJoinedEvent(roomId, sessionId, username));
+    }
+
+    public void notifyMemberLocation(Long channelId, Member member) {
+        eventPublisher.publishEvent(new MemberLocationEvent(channelId, member));
+    }
+}

--- a/src/main/java/com/curioussong/alsongdalsong/room/service/RoomService.java
+++ b/src/main/java/com/curioussong/alsongdalsong/room/service/RoomService.java
@@ -11,14 +11,13 @@ import com.curioussong.alsongdalsong.game.messaging.GameMessageSender;
 import com.curioussong.alsongdalsong.game.repository.GameRepository;
 import com.curioussong.alsongdalsong.game.timer.GameTimerManager;
 import com.curioussong.alsongdalsong.member.domain.Member;
-import com.curioussong.alsongdalsong.member.event.MemberLocationEvent;
 import com.curioussong.alsongdalsong.member.repository.MemberRepository;
 import com.curioussong.alsongdalsong.room.domain.Room;
 import com.curioussong.alsongdalsong.room.dto.*;
 import com.curioussong.alsongdalsong.room.event.RoomEventNotifier;
 import com.curioussong.alsongdalsong.room.event.RoomUpdatedEvent;
-import com.curioussong.alsongdalsong.room.event.UserJoinedEvent;
 import com.curioussong.alsongdalsong.room.repository.RoomRepository;
+import com.curioussong.alsongdalsong.room.util.RoomValidator;
 import com.curioussong.alsongdalsong.roomgame.domain.RoomGame;
 import com.curioussong.alsongdalsong.roomgame.repository.RoomGameRepository;
 import com.curioussong.alsongdalsong.roomyear.domain.RoomYear;
@@ -56,8 +55,6 @@ public class RoomService {
     private final GameTimerManager gameTimerManager;
     private final RoomEventNotifier roomEventNotifier;
 
-    private static final List<Integer> VALID_YEARS = List.of(1970, 1980, 1990, 2000, 2010, 2020, 2021, 2022, 2023, 2024);
-
     @Transactional
     public CreateResponse createRoom(Member member, CreateRequest request) {
         Channel channel = channelRepository.findById(request.getChannelId())
@@ -66,7 +63,7 @@ public class RoomService {
                         "존재하지 않는 채널입니다."
                 ));
 
-        validateRoomSettings(request.getFormat(), request.getMaxPlayer(), request.getMaxGameRound(), request.getPassword(), request.getTitle());
+        RoomValidator.validateRoomSettings(request.getFormat(), request.getMaxPlayer(), request.getMaxGameRound(), request.getPassword(), request.getTitle());
 
         Room room = createRoomEntity(member, channel, request);
         roomEventNotifier.notifyMemberLocation(channel.getId(), member);
@@ -171,7 +168,7 @@ public class RoomService {
     }
 
     private boolean isHostLeaving(Room room, Member member) {
-        return member.getId().equals(room.getHost().getId());
+        return room.isHost(member);
     }
 
     private boolean delegateHost(Room room, Member member) {
@@ -193,7 +190,7 @@ public class RoomService {
     public void updateRoom(Member member, UpdateRequest request) {
         Room room = findRoomById(request.getRoomId());
 
-        validateRoomHost(room, member);
+        RoomValidator.validateRoomHost(room, member);
 
         if(!room.getFormat().name().equals(request.getFormat())) {
             throw new HttpClientErrorException(
@@ -202,7 +199,7 @@ public class RoomService {
             );
         }
 
-        validateRoomSettings(request.getFormat(), request.getMaxPlayer(), request.getMaxGameRound(), request.getPassword(), request.getTitle());
+        RoomValidator.validateRoomSettings(request.getFormat(), request.getMaxPlayer(), request.getMaxGameRound(), request.getPassword(), request.getTitle());
 
         if (room.getMembers().size() > request.getMaxPlayer()) {
             throw new HttpClientErrorException(
@@ -347,46 +344,6 @@ public class RoomService {
         return (maxRoomNumber != null) ? maxRoomNumber + 1 : 1;
     }
 
-
-    private void validateRoomSettings(String format, Integer maxPlayer, Integer maxGameRound, String password, String title){
-        if("BOARD".equals(format)){
-            if(maxPlayer>6 || maxPlayer<2) {
-                throw new HttpClientErrorException(
-                        HttpStatus.BAD_REQUEST,
-                        "보드판 맵의 최대 인원은 2~6명입니다."
-                );
-            }
-        } else if ("GENERAL".equals(format)) {
-            if(maxPlayer>60 || maxPlayer<2){
-                throw new HttpClientErrorException(
-                        HttpStatus.BAD_REQUEST,
-                        "점수판 맵의 최대 인원은 2~60명입니다. "
-                );
-            }
-        }
-
-        if(!(maxGameRound == 5 || maxGameRound == 10 || maxGameRound == 20 || maxGameRound == 30)){
-            throw new HttpClientErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "게임 라운드는 5, 10, 20, 30 중 하나여야 합니다."
-            );
-        }
-
-        if(password.length()>30){
-            throw new HttpClientErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "방의 비밀번호는 30자 이하여야 합니다."
-            );
-        }
-
-        if(title.length() > 15){
-            throw new HttpClientErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "방의 제목은 15 이내여야 합니다."
-            );
-        }
-    }
-
     private List<Game> getGamesFromModes(List<GameMode> gameModes) {
         if (gameModes == null || gameModes.isEmpty()) {
             throw new HttpClientErrorException(
@@ -408,24 +365,6 @@ public class RoomService {
                 .distinct()
                 .map(year -> new RoomYear(room, year))
                 .toList();
-    }
-
-    private void validateYears(List<Integer> years) {
-        if (years == null || years.isEmpty()) {
-            throw new HttpClientErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "선택된 연도가 없습니다."
-            );
-        }
-
-        for (Integer year : years) {
-            if (year == null || !VALID_YEARS.contains(year)) {
-                throw new HttpClientErrorException(
-                        HttpStatus.BAD_REQUEST,
-                        "지원하지 않는 연도가 포함되어 있습니다"
-                );
-            }
-        }
     }
 
     private Room findRoomById(String roomId) {
@@ -450,15 +389,6 @@ public class RoomService {
         gameMessageSender.sendUserInfo(destination, userInfoList, allReady);
     }
 
-    private void validateRoomHost(Room room, Member member) {
-        if (!room.getHost().getId().equals(member.getId())) {
-            throw new HttpClientErrorException(
-                    HttpStatus.UNAUTHORIZED,
-                    "방 설정은 방장만 변경 가능합니다."
-            );
-        }
-    }
-
     private void updateRoomGames(Room room, List<GameMode> gameModes) {
         roomGameRepository.deleteAllByRoom(room);
         List<Game> games = getGamesFromModes(gameModes);
@@ -472,7 +402,7 @@ public class RoomService {
         roomYearRepository.deleteAllByRoom(room);
         roomYearRepository.flush();
 
-        validateYears(selectedYears);
+        RoomValidator.validateYears(selectedYears);
         List<RoomYear> newRoomYears = createRoomYears(room, selectedYears);
         roomYearRepository.saveAll(newRoomYears);
     }
@@ -504,7 +434,7 @@ public class RoomService {
     }
 
     private void setupRoomYears(Room room, List<Integer> selectedYears) {
-        validateYears(selectedYears);
+        RoomValidator.validateYears(selectedYears);
         List<RoomYear> roomYears = createRoomYears(room, selectedYears);
         roomYearRepository.saveAll(roomYears);
     }

--- a/src/main/java/com/curioussong/alsongdalsong/room/service/RoomService.java
+++ b/src/main/java/com/curioussong/alsongdalsong/room/service/RoomService.java
@@ -15,6 +15,7 @@ import com.curioussong.alsongdalsong.member.event.MemberLocationEvent;
 import com.curioussong.alsongdalsong.member.repository.MemberRepository;
 import com.curioussong.alsongdalsong.room.domain.Room;
 import com.curioussong.alsongdalsong.room.dto.*;
+import com.curioussong.alsongdalsong.room.event.RoomEventNotifier;
 import com.curioussong.alsongdalsong.room.event.RoomUpdatedEvent;
 import com.curioussong.alsongdalsong.room.event.UserJoinedEvent;
 import com.curioussong.alsongdalsong.room.repository.RoomRepository;
@@ -26,7 +27,6 @@ import com.curioussong.alsongdalsong.common.util.Destination;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
 public class RoomService {
 
     private final RoomRepository roomRepository;
-    private final ApplicationEventPublisher eventPublisher;
     private final MemberRepository memberRepository;
     private final GameRepository gameRepository;
     private final RoomYearRepository roomYearRepository;
@@ -55,6 +54,7 @@ public class RoomService {
     private final InGameManager inGameManager;
     private final GameMessageSender gameMessageSender;
     private final GameTimerManager gameTimerManager;
+    private final RoomEventNotifier roomEventNotifier;
 
     private static final List<Integer> VALID_YEARS = List.of(1970, 1980, 1990, 2000, 2010, 2020, 2021, 2022, 2023, 2024);
 
@@ -69,7 +69,7 @@ public class RoomService {
         validateRoomSettings(request.getFormat(), request.getMaxPlayer(), request.getMaxGameRound(), request.getPassword(), request.getTitle());
 
         Room room = createRoomEntity(member, channel, request);
-        eventPublisher.publishEvent(new MemberLocationEvent(channel.getId(), member));
+        roomEventNotifier.notifyMemberLocation(channel.getId(), member);
         setupRoomGames(room, request.getGameModes());
         setupRoomYears(room, request.getSelectedYears());
         notifyRoomCreation(room, request.getChannelId());
@@ -95,9 +95,9 @@ public class RoomService {
 
         sendRoomAndUserInfo(channelId, roomId, room);
 
-        eventPublisher.publishEvent(new UserJoinedEvent(room.getId(), sessionId, userName));
-        eventPublisher.publishEvent(new RoomUpdatedEvent(room, channelId, RoomUpdatedEvent.ActionType.UPDATED));
-        eventPublisher.publishEvent(new MemberLocationEvent(channelId, member));
+        roomEventNotifier.notifyUserJoined(room.getId(), sessionId, userName);
+        roomEventNotifier.notifyRommEvent(room, channelId, RoomUpdatedEvent.ActionType.UPDATED);
+        roomEventNotifier.notifyMemberLocation(channelId, member);
     }
 
     @Transactional
@@ -115,7 +115,7 @@ public class RoomService {
 
         updateClientsAfterLeave(channelId, roomId, room, isFinished);
 
-        eventPublisher.publishEvent(new MemberLocationEvent(channelId, member));
+        roomEventNotifier.notifyMemberLocation(channelId, member);
         log.debug("이벤트 발행 완료");
     }
 
@@ -149,7 +149,7 @@ public class RoomService {
         roomRepository.save(room);
         roomRepository.flush(); // 즉시 DB에 반영
 
-        eventPublisher.publishEvent(new RoomUpdatedEvent(room, channelId, RoomUpdatedEvent.ActionType.FINISHED));
+        roomEventNotifier.notifyRommEvent(room, channelId, RoomUpdatedEvent.ActionType.FINISHED);
         return true;
     }
 
@@ -164,7 +164,7 @@ public class RoomService {
     private void updateClientsAfterLeave(Long channelId, String roomId, Room room, boolean isFinished) {
         if (!isFinished) {
             sendRoomAndUserInfo(channelId, roomId, room);
-            eventPublisher.publishEvent(new RoomUpdatedEvent(room, channelId, RoomUpdatedEvent.ActionType.UPDATED));
+            roomEventNotifier.notifyRommEvent(room, channelId, RoomUpdatedEvent.ActionType.UPDATED);
         } else {
             sendRoomAndUserInfo(channelId, roomId, room);
         }
@@ -179,7 +179,7 @@ public class RoomService {
         if (remainingMembers.isEmpty()) {
             room.updateStatus(Room.RoomStatus.FINISHED);
             roomRepository.save(room);
-            eventPublisher.publishEvent(new RoomUpdatedEvent(room, room.getChannel().getId(), RoomUpdatedEvent.ActionType.FINISHED));
+            roomEventNotifier.notifyRommEvent(room, room.getChannel().getId(), RoomUpdatedEvent.ActionType.FINISHED);
             return true;
         } else {
             Member newHost = remainingMembers.get(0);
@@ -220,7 +220,7 @@ public class RoomService {
         updateRoomYears(room, request.getSelectedYears());
 
         roomManager.updateRoomInfo(room, request.getSelectedYears());
-        eventPublisher.publishEvent(new RoomUpdatedEvent(room, room.getChannel().getId(), RoomUpdatedEvent.ActionType.UPDATED));
+        roomEventNotifier.notifyRommEvent(room, room.getChannel().getId(), RoomUpdatedEvent.ActionType.UPDATED);
     }
 
     @Transactional(readOnly=true)
@@ -509,7 +509,7 @@ public class RoomService {
         roomYearRepository.saveAll(roomYears);
     }
     private void notifyRoomCreation(Room room, Long channelId) {
-        eventPublisher.publishEvent(new RoomUpdatedEvent(room, room.getChannel().getId(), RoomUpdatedEvent.ActionType.CREATED));
+        roomEventNotifier.notifyRommEvent(room, room.getChannel().getId(), RoomUpdatedEvent.ActionType.CREATED);
         roomManager.addRoomInfo(room, channelId);
     }
 

--- a/src/main/java/com/curioussong/alsongdalsong/room/util/RoomValidator.java
+++ b/src/main/java/com/curioussong/alsongdalsong/room/util/RoomValidator.java
@@ -1,0 +1,79 @@
+package com.curioussong.alsongdalsong.room.util;
+
+import com.curioussong.alsongdalsong.member.domain.Member;
+import com.curioussong.alsongdalsong.room.domain.Room;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.List;
+
+public class RoomValidator {
+
+    private static final List<Integer> VALID_YEARS = List.of(1970, 1980, 1990, 2000, 2010, 2020, 2021, 2022, 2023, 2024);
+
+    public static void validateYears(List<Integer> years) {
+        if (years == null || years.isEmpty()) {
+            throw new HttpClientErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "선택된 연도가 없습니다."
+            );
+        }
+
+        for (Integer year : years) {
+            if (year == null || !VALID_YEARS.contains(year)) {
+                throw new HttpClientErrorException(
+                        HttpStatus.BAD_REQUEST,
+                        "지원하지 않는 연도가 포함되어 있습니다"
+                );
+            }
+        }
+    }
+
+    public static void validateRoomSettings(String format, Integer maxPlayer, Integer maxGameRound, String password, String title){
+        if("BOARD".equals(format)){
+            if(maxPlayer>6 || maxPlayer<2) {
+                throw new HttpClientErrorException(
+                        HttpStatus.BAD_REQUEST,
+                        "보드판 맵의 최대 인원은 2~6명입니다."
+                );
+            }
+        } else if ("GENERAL".equals(format)) {
+            if(maxPlayer>60 || maxPlayer<2){
+                throw new HttpClientErrorException(
+                        HttpStatus.BAD_REQUEST,
+                        "점수판 맵의 최대 인원은 2~60명입니다. "
+                );
+            }
+        }
+
+        if(!(maxGameRound == 5 || maxGameRound == 10 || maxGameRound == 20 || maxGameRound == 30)){
+            throw new HttpClientErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "게임 라운드는 5, 10, 20, 30 중 하나여야 합니다."
+            );
+        }
+
+        if(password.length()>30){
+            throw new HttpClientErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "방의 비밀번호는 30자 이하여야 합니다."
+            );
+        }
+
+        if(title.length() > 15){
+            throw new HttpClientErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "방의 제목은 15 이내여야 합니다."
+            );
+        }
+    }
+
+    public static void validateRoomHost(Room room, Member member) {
+        if (!room.isHost(member)) {
+            throw new HttpClientErrorException(
+                    HttpStatus.UNAUTHORIZED,
+                    "방 설정은 방장만 변경 가능합니다."
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 🤷‍♂ Description

- 이벤트 발행 책임 분리
서비스 로직에서 이벤트에 대한 비즈니스 로직도 담당하고 있어 책임을 분리하기 위해 `RoomEventNotifier` 클래스를 도입해 이벤트 발행을 전담하도록 하였습니다
<br>

- Room 관련 검증 로직 분리
`validateYears`, `validateRoomSettings`, `validateRoomHost` 와 같은 메서드들을 `RoomValidator` 클래스가 전담하도록 하였고 의존성 주입이 필요없다고 판단하여 정적 메소드로 선언하였습니다

  `member.getId().equals(room.getHost().getId())` 의 경우 roomService 외에도 다양한 곳에서 쓸 수 있다고 생각해 Room 도메인에 `isHost` 메서드를 생성해 사용였습니다

<br>

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

그래도 서비스가 담당하고 있는 로직이 많다고 생각하여 더 개선할 점을 찾아야 할 것 같습니다